### PR TITLE
fix: change husky prepare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "postbuild": "next-sitemap --config next-sitemap.config.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "postinstall": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide"
   },
   "husky": {


### PR DESCRIPTION
### Issue 😱:

Closes https://github.com/Skolaczk/next-starter/issues/107

### What has been done ✅:

- changed the husky preapre command to compatible with version 9.0.0 of husky

